### PR TITLE
Fix minor indentation issues and track dub lock file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+
+[*.d]
+indent_size = 4
+
+[*.json]
+indent_size = 2

--- a/dub.json
+++ b/dub.json
@@ -1,42 +1,42 @@
 {
-	"name": "dubtestproject",
-	"authors": [
-		"Meson Team"
-	],
-	"description": "A test project.",
-	"copyright": "Copyright © 2018, Meson Team",
-	"license": "MIT",
-	"homepage": "http://mesonbuild.com",
-	"targetType": "none",
-	"dependencies": {
-		"dubtestproject:test1": ">=0.0.0",
-		"dubtestproject:test2": ">=0.0.0",
-		"dubtestproject:test3": ">=0.0.0"
-	},
-	"subPackages": [
-		{
-			"name": "test1",
-			"targetType": "executable",
-			"targetName": "test1",
-			"sourcePaths": [
-				"source/test1"
-			]
-		},
-		{
-			"name": "test2",
-			"targetType": "library",
-			"targetName": "test2",
-			"sourcePaths": [
-				"source/test2"
-			]
-		},
-		{
-                        "name": "test3",
-                        "targetType": "staticLibrary",
-                        "targetName": "test3",
-                        "sourcePaths": [
-                                "source/test3"
-                        ]
-                }
-	]
+  "name": "dubtestproject",
+  "authors": [
+    "Meson Team"
+  ],
+  "description": "A test project.",
+  "copyright": "Copyright © 2018, Meson Team",
+  "license": "MIT",
+  "homepage": "http://mesonbuild.com",
+  "targetType": "none",
+  "dependencies": {
+    "dubtestproject:test1": ">=0.0.0",
+    "dubtestproject:test2": ">=0.0.0",
+    "dubtestproject:test3": ">=0.0.0"
+  },
+  "subPackages": [
+    {
+      "name": "test1",
+      "targetType": "executable",
+      "targetName": "test1",
+      "sourcePaths": [
+        "source/test1"
+      ]
+    },
+    {
+      "name": "test2",
+      "targetType": "library",
+      "targetName": "test2",
+      "sourcePaths": [
+        "source/test2"
+      ]
+    },
+    {
+      "name": "test3",
+      "targetType": "staticLibrary",
+      "targetName": "test3",
+      "sourcePaths": [
+        "source/test3"
+      ]
+    }
+  ]
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,5 @@
+{
+  "fileVersion": 1,
+  "versions": {
+  }
+}

--- a/source/test1/test.d
+++ b/source/test1/test.d
@@ -2,5 +2,5 @@ import std.stdio;
 
 void main()
 {
-	writeln("It works!");
+    writeln("It works!");
 }

--- a/source/test2/test.d
+++ b/source/test2/test.d
@@ -4,5 +4,5 @@ import std.stdio;
 
 void printTest()
 {
-	writeln("printTest() called");
+    writeln("printTest() called");
 }

--- a/source/test3/test.d
+++ b/source/test3/test.d
@@ -2,5 +2,5 @@ import std.stdio;
 
 void main()
 {
-	writeln("It works!");
+    writeln("It works!");
 }


### PR DESCRIPTION
I'm currently planing doing some extra unittests to cover some reported issues on D modules and found that I committed some spaces instead of tabs.

Also, `dub.selections.json` should be tracked by git as it is a lock file for versions described on `dub.json`. Although, we don't have any dependencies here nor doing version pinning and the `dub.selections.json` is almost empty, it's a good practice to have it there.

e.g.: See the official repository, https://github.com/dlang/dub