### PR TITLE
Add test4 and test5 subpackages and add some missing pieces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/.vscode
+/.dub
+
+.DS_Store
+*~
+
+/bin

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2018-2020, Meson Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/dub.json
+++ b/dub.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "dubtestproject:test1": ">=0.0.0",
     "dubtestproject:test2": ">=0.0.0",
-    "dubtestproject:test3": ">=0.0.0"
+    "dubtestproject:test3": ">=0.0.0",
+    "dubtestproject:test4": ">=0.0.0",
+    "dubtestproject:test5": ">=0.0.0"
   },
   "subPackages": [
     {
@@ -36,6 +38,22 @@
       "targetName": "test3",
       "sourcePaths": [
         "source/test3"
+      ]
+    },
+    {
+      "name": "test4",
+      "targetType": "sourceLibrary",
+      "targetName": "test4",
+      "sourcePaths": [
+        "source/test4"
+      ]
+    },
+    {
+      "name": "test5",
+      "targetType":"dynamicLibrary",
+      "targetName": "test5",
+      "sourcePaths": [
+        "source/test5"
       ]
     }
   ]

--- a/dub.json
+++ b/dub.json
@@ -20,6 +20,7 @@
       "name": "test1",
       "targetType": "executable",
       "targetName": "test1",
+      "targetPath": "bin",
       "sourcePaths": [
         "source/test1"
       ]
@@ -28,6 +29,7 @@
       "name": "test2",
       "targetType": "library",
       "targetName": "test2",
+      "targetPath": "bin",
       "sourcePaths": [
         "source/test2"
       ]
@@ -36,6 +38,7 @@
       "name": "test3",
       "targetType": "staticLibrary",
       "targetName": "test3",
+      "targetPath": "bin",
       "sourcePaths": [
         "source/test3"
       ]
@@ -43,6 +46,7 @@
     {
       "name": "test4",
       "targetType": "sourceLibrary",
+      "targetPath": "bin",
       "targetName": "test4",
       "sourcePaths": [
         "source/test4"
@@ -51,6 +55,7 @@
     {
       "name": "test5",
       "targetType":"dynamicLibrary",
+      "targetPath": "bin",
       "targetName": "test5",
       "sourcePaths": [
         "source/test5"

--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,7 @@
     "Meson Team"
   ],
   "description": "A test project.",
-  "copyright": "Copyright © 2018, Meson Team",
+  "copyright": "Copyright © 2018-2020, Meson Team",
   "license": "MIT",
   "homepage": "http://mesonbuild.com",
   "targetType": "none",

--- a/source/test4/test.d
+++ b/source/test4/test.d
@@ -1,0 +1,3 @@
+module meson.test;
+
+enum SOURCE_LIBRARY_TEST = "meson";

--- a/source/test5/test.d
+++ b/source/test5/test.d
@@ -1,0 +1,8 @@
+module meson.test;
+
+import std.stdio;
+
+void printTest()
+{
+    writeln("printTest() called");
+}


### PR DESCRIPTION
This PR adds `test4` and `test5` sub-packages. The intention here is to test the behavior for `sourceLibrary` and `dynamicLibrary`, respectively.

There's some active issues reporting some bad behaviors when using this type of targets, such as, https://github.com/mesonbuild/meson/issues/6581 and https://github.com/mesonbuild/meson/issues/7560 .

Additionally, this PR changes the default `targetPath` to output the compiled binaries into a different folder and adds a simple `.gitignore` and a matching license, previously stated on `dub.json`. See here: https://github.com/mesonbuild/dubtestproject/blob/master/dub.json#L8 .